### PR TITLE
fix: shallow copy the options correctly

### DIFF
--- a/.changeset/kind-laws-hang.md
+++ b/.changeset/kind-laws-hang.md
@@ -1,0 +1,5 @@
+---
+'@yonycalsin/eslint-plugin-import-sort': minor
+---
+
+fix: cannot assign to read only property 'options' of object '#<Object>' #15

--- a/packages/eslint-plugin-import-sort/src/rules/typescript-react-imports.ts
+++ b/packages/eslint-plugin-import-sort/src/rules/typescript-react-imports.ts
@@ -33,8 +33,9 @@ export = defineRule({
 
     const groups = modulesToGroups(options.modules ?? undefined)
 
-    context.options = [{ groups }]
-
-    return simpleImportSort.rules.imports.create(context)
+    return simpleImportSort.rules.imports.create({
+      ...context,
+      options: [{ groups }],
+    })
   },
 })


### PR DESCRIPTION
closes https://github.com/yonycalsin/eslint-config/issues/15